### PR TITLE
Parallel tests instead of serial ones

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_INIT([patchelf], m4_esyscmd([printf $(cat ./version)]))
 AC_CONFIG_SRCDIR([src/patchelf.cc])
 AC_CONFIG_AUX_DIR([build-aux])
-AM_INIT_AUTOMAKE([-Wall -Werror dist-bzip2 foreign color-tests serial-tests])
+AM_INIT_AUTOMAKE([1.11.1 -Wall -Werror dist-bzip2 foreign color-tests parallel-tests])
 
 AM_PROG_CC_C_O
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -1,3 +1,4 @@
+AC_PREREQ([2.62])
 AC_INIT([patchelf], m4_esyscmd([printf $(cat ./version)]))
 AC_CONFIG_SRCDIR([src/patchelf.cc])
 AC_CONFIG_AUX_DIR([build-aux])
@@ -13,7 +14,7 @@ AC_ARG_WITH([page-size],
 )
 
 if test "$PAGESIZE" = auto; then
-    if command -v getconf >/dev/null; then
+    if type -p getconf &>/dev/null; then
         PAGESIZE=$(getconf PAGESIZE || getconf PAGE_SIZE)
     fi
     if test "$PAGESIZE" = auto -o -z "$PAGESIZE"; then

--- a/tests/no-rpath-prebuild.sh
+++ b/tests/no-rpath-prebuild.sh
@@ -4,7 +4,7 @@ ARCH="$1"
 PAGESIZE=4096
 
 if [ -z "$ARCH" ]; then
-  ARCH=$(basename $0 .sh | sed -e 's/.*-//')
+  ARCH=$(basename $0 .sh | sed -e 's/^no-rpath-//')
 fi
 
 SCRATCH=scratch/no-rpath-$ARCH


### PR DESCRIPTION
Applied the patch proposed by chewi@aura-online.co.uk to avoid a failure in autoconf on Redhat 6 and derivatives because it doesn't understand serial-tests.